### PR TITLE
add 16:10 aspect ratio

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -269,6 +269,12 @@ fn ratio_select() -> Result<EngineRatio, std::io::Error> {
 
     let common_ratios = vec![
         EngineRatio {
+            name: "16:10".into(),
+            hex: hex!("CD CC CC 3F"),
+            height: 10.0,
+            width: 16.0,
+        },
+        EngineRatio {
             name: "21:9 (2560x1080)".into(),
             hex: hex!("26 B4 17 40"),
             height: 9.0,


### PR DESCRIPTION
Adds 16:10 to the list of known aspect ratios. Should make it easier to patch for Steam Deck.